### PR TITLE
Reduce NLOOPS to diminish test duration

### DIFF
--- a/tests/arrays-1/main.java
+++ b/tests/arrays-1/main.java
@@ -2,7 +2,7 @@ import java.lang.Thread;
 
 public class main {
 
-    final static int NLOOPS = 10000000;
+    final static int NLOOPS = 1_000_000;
 
     private static void showResult(String elemType, int length, long t1, long t2) {
         double elapsedSeconds = (double) (t2 - t1) / 1000.0;


### PR DESCRIPTION
Changed from 10M to 1M, so as to not slow the test runs.